### PR TITLE
bumped node to 18 which passes the test suite

### DIFF
--- a/pipelines/nodejs-app-testing.yml
+++ b/pipelines/nodejs-app-testing.yml
@@ -10,7 +10,7 @@ resources:
   type: registry-image
   source:
     repository: node
-    tag: 13.10.1-stretch
+    tag: 18
 
 jobs:
 - name: test


### PR DESCRIPTION
I was reviewing the [node example](https://concourse-ci.org/nodejs-example.html) on the concourse doc site when I noticed the pipeline had been failing for a while.

This PR will fix that

Gary

Signed-off-by: Gary Bright <digitalgaz@hotmail.com>