### PR TITLE
PHP: Change Project to Laravel Application

### DIFF
--- a/pipelines/php-larvel-app-testing.yml
+++ b/pipelines/php-larvel-app-testing.yml
@@ -1,16 +1,16 @@
 ---
 resources:
-- name: larvel-websockets-git
+- name: laravel-git
   type: git
   icon: github
   source:
-    uri: https://github.com/beyondcode/laravel-websockets.git
+    uri: https://github.com/laravel/laravel.git
 
 jobs:
 - name: test
   public: true
   plan:
-  - get: larvel-websockets-git
+  - get: laravel-git
     trigger: true
   - task: run-tests
     config:
@@ -19,13 +19,17 @@ jobs:
         type: registry-image
         source: { repository: composer }
       inputs:
-        - name: larvel-websockets-git
+        - name: laravel-git
       run:
         path: /bin/sh
         args:
-          - -c
+          - -ce
           - |
-            cd larvel-websockets-git
+            cd laravel-git
 
             composer install
-            vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+            cp .env.example .env
+            php artisan key:generate
+
+            vendor/bin/phpunit


### PR DESCRIPTION
The Beyond Code Laravel Websockets project was archived in February 2024.

I removed the `--coverage` flags because they caused errors about a missing driver (probably xdebug).

I had considered testing the [Laravel framework](https://github.com/laravel/framework) so there were more tests, but it required extra PHP extensions that were not installed by default. It also gets more commits which would trigger more pipelines.

If we are not interested in testing an actual Laravel application, I could add a small PHP application into the [apps directory](https://github.com/concourse/examples/tree/master/apps) and write a few tests for it. That way we have more control over changes instead of relying on upstream projects not breaking something.