### PR TITLE
Node: Fix Package Not Found Errors

### DIFF
--- a/pipelines/nodejs-app-testing.yml
+++ b/pipelines/nodejs-app-testing.yml
@@ -8,9 +8,10 @@ resources:
 
 - name: node-image
   type: registry-image
+  icon: docker
   source:
     repository: node
-    tag: 18
+    tag: 22
 
 jobs:
 - name: test
@@ -25,20 +26,19 @@ jobs:
       inputs:
       - name: repo
       outputs:
-      - name: dependencies
-        path: repo/node_modules
+      - name: workspace
+        path: repo
       platform: linux
       run:
         path: npm
-        args: ["install"]
+        args: ["ci", "--no-audit", "--no-fund"]
         dir: repo
   - task: test
     image: node-image
     config:
       inputs:
-      - name: repo
-      - name: dependencies
-        path: repo/node_modules
+      - name: workspace
+        path: repo
       platform: linux
       run:
         path: npm


### PR DESCRIPTION
After running `npm install` there are multiple node_modules directories created. I believe this is because the project is utilizing [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces).

The node_modules directories created by `npm install`:

- node_modules
- packages/ui-components/node_modules
- packages/i18n/node_modules
- apps/site/node_modules

There are two options I could think of to make this work. First we could run both `npm install` and `npm run test` in the same step. This doesn't follow a typical flow of projects that will be using Concourse. I typically see one step for install and build and one for tests. The second option is copy the entire repo as an output. This feels a little dirty, but seems like a more typical flow.

I went with the second option to keep the steps separate. I wasn't sure if I should reuse the "repo" name as an output. I went  with "workspace" to show that it was different from "repo" (upstream git).

I updated the image to `node:22` because it seems like that is [the one the project wants](https://github.com/nodejs/nodejs.org/blob/main/package.json#L15-L17).

I switched from `npm install` to `npm ci` because the [ci command](https://docs.npmjs.com/cli/v10/commands/npm-ci) is better suited for our use case and should be more performant.

Please let me know if you want any changes to this pull request. I'm not married to this specific solution.