### PR TITLE
Reorganize Rails Example to Match Other Pipelines

### DIFF
--- a/pipelines/rails-app-testing.yml
+++ b/pipelines/rails-app-testing.yml
@@ -6,35 +6,6 @@ resources:
   source:
     uri: https://github.com/rails/rails-contributors.git
 
-task-config: &task-config
-  platform: linux
-  inputs:
-    - name: rails-contributors-git
-  params:
-    RAILS_ENV: test
-    DATABASE_URL: postgresql://postgres@localhost
-  run:
-    path: /bin/bash
-    args:
-      - -c
-      - |
-        echo "=== Setting up Postgres..."
-        apt-get update
-        apt-get install -y postgresql libpq-dev cmake nodejs
-        cat > /etc/postgresql/*/main/pg_hba.conf <<-EOF
-        host   all   postgres   localhost   trust
-        EOF
-        service postgresql restart
-        echo "=== Project requires that we clone rails... "
-        cd rails-contributors-git
-        git clone --mirror https://github.com/rails/rails
-        echo "=== Installing Gems..."
-        gem install -N bundler
-        bundle install
-        echo "=== Running Tests..."
-        bundle exec rails db:setup
-        bundle exec rails test
-
 jobs:
 - name: test
   public: true
@@ -45,7 +16,37 @@ jobs:
       trigger: true
     - task: run-tests
       config:
+        platform: linux
         image_resource:
           type: registry-image
           source: { repository: ruby, tag: 3.3.4 }
-        << : *task-config
+        inputs:
+          - name: rails-contributors-git
+        params:
+          RAILS_ENV: test
+          DATABASE_URL: postgresql://postgres@localhost
+        run:
+          path: /bin/bash
+          args:
+            - -ce
+            - |
+              cd rails-contributors-git
+
+              echo "=== Setting up Postgres ==="
+              apt-get update
+              apt-get install -y postgresql libpq-dev cmake nodejs
+              cat > /etc/postgresql/*/main/pg_hba.conf <<-EOF
+              host   all   postgres   localhost   trust
+              EOF
+              service postgresql restart
+
+              echo "=== Project requires that we clone rails ==="
+              git clone --mirror https://github.com/rails/rails.git
+
+              echo "=== Installing Gems ==="
+              gem install -N bundler
+              bundle install
+
+              echo "=== Running Tests ==="
+              bundle exec rails db:setup
+              bundle exec rails test


### PR DESCRIPTION
Reorganizes the pipeline to match the other examples. Add a little space between commands to make it easier to read what is going on.